### PR TITLE
unpack tar with numeric id's

### DIFF
--- a/scripts/copy_rootfs.sh
+++ b/scripts/copy_rootfs.sh
@@ -79,7 +79,7 @@ echo "Mounting ${DEV}"
 sudo mount ${DEV} /media/card
 
 echo "Extracting ${IMAGE}-image-${MACHINE}.tar.xz to /media/card"
-sudo tar -C /media/card -xJf ${SRCDIR}/${IMAGE}-image-${MACHINE}.tar.xz
+sudo tar --numeric-owner -C /media/card -xJf ${SRCDIR}/${IMAGE}-image-${MACHINE}.tar.xz
 
 echo "Writing ${TARGET_HOSTNAME} to /etc/hostname"
 export TARGET_HOSTNAME


### PR DESCRIPTION
tar use normally user/groupname and not uid/gid
host system will leak into image!
see: http://lists.openembedded.org/pipermail/openembedded-core/2014-October/097945.html