### PR TITLE
Added mount verify in copy-scripts

### DIFF
--- a/scripts/copy_boot.sh
+++ b/scripts/copy_boot.sh
@@ -44,6 +44,11 @@ if [ ! -d /media/card ]; then
 	exit 1
 fi
 
+if mount | grep " /media/card " > /dev/null; then
+    echo "Something is already mounted in folder /media/card"
+    exit 1
+fi
+
 if [ -z "$OETMP" ]; then
 	echo -e "\nWorking from local directory"
 	SRCDIR=.
@@ -97,6 +102,11 @@ sudo mkfs.vfat -F 32 ${DEV} -n BOOT
 
 echo "Mounting ${DEV}"
 sudo mount ${DEV} /media/card
+
+if ! mount | grep ${DEV} > /dev/null; then
+    echo "Failed to mount device: ${DEV}"
+    exit 1
+fi
 
 echo "Copying bootloader files"
 sudo cp ${SRCDIR}/bcm2835-bootfiles/* /media/card

--- a/scripts/copy_boot.sh
+++ b/scripts/copy_boot.sh
@@ -103,8 +103,9 @@ sudo mkfs.vfat -F 32 ${DEV} -n BOOT
 echo "Mounting ${DEV}"
 sudo mount ${DEV} /media/card
 
-if ! mount | grep ${DEV} > /dev/null; then
-    echo "Failed to mount device: ${DEV}"
+M_RET=$?
+if [ ${M_RET} -ne 0 ]; then
+    echo "Failed to mount device '${DEV}' with error code ${M_RET}"
     exit 1
 fi
 

--- a/scripts/copy_rootfs.sh
+++ b/scripts/copy_rootfs.sh
@@ -83,8 +83,9 @@ sudo mkfs.ext4 -q -L ROOT ${DEV}
 echo "Mounting ${DEV}"
 sudo mount ${DEV} /media/card
 
-if ! mount | grep ${DEV} > /dev/null; then
-    echo "Failed to mount device: ${DEV}"
+M_RET=$?
+if [ ${M_RET} -ne 0 ]; then
+    echo "Failed to mount device '${DEV}' with error code ${M_RET}"
     exit 1
 fi
 

--- a/scripts/copy_rootfs.sh
+++ b/scripts/copy_rootfs.sh
@@ -21,6 +21,11 @@ if [ ! -d /media/card ]; then
 	exit 1
 fi
 
+if mount | grep " /media/card " > /dev/null; then
+    echo "Something is already mounted in folder /media/card"
+    exit 1
+fi
+
 if [ "x${2}" = "x" ]; then
         IMAGE=console
 else
@@ -77,6 +82,11 @@ sudo mkfs.ext4 -q -L ROOT ${DEV}
 
 echo "Mounting ${DEV}"
 sudo mount ${DEV} /media/card
+
+if ! mount | grep ${DEV} > /dev/null; then
+    echo "Failed to mount device: ${DEV}"
+    exit 1
+fi
 
 echo "Extracting ${IMAGE}-image-${MACHINE}.tar.xz to /media/card"
 sudo tar --numeric-owner -C /media/card -xJf ${SRCDIR}/${IMAGE}-image-${MACHINE}.tar.xz


### PR DESCRIPTION
When copying the files to a sdcard it is useful to make sure that
we don't mount the partitions on top of something else and verify
that the mount actually succeeded. Mount can fail e.g. if the
partitioning has failed.