### PR TITLE
adds recipes and image to build PyQt5 (5.9.2)

### DIFF
--- a/images/pyqt5-image.bb
+++ b/images/pyqt5-image.bb
@@ -1,0 +1,11 @@
+SUMMARY = "A PyQt5 development image"
+HOMEPAGE = "http://www.jumpnowtek.com"
+LICENSE = "MIT"
+
+require qt5-image.bb
+
+QT5_PKGS += " \
+    python-pyqt5 \
+"
+
+export IMAGE_BASENAME = "pyqt5-image"

--- a/recipes-qt/python-pyqt5/python-pyqt5_5.8.2.bbappend
+++ b/recipes-qt/python-pyqt5/python-pyqt5_5.8.2.bbappend
@@ -1,0 +1,16 @@
+PV = "5.9.2"
+SRC_URI[md5sum] = "33d6d2ab8183da17ac18b8132a4b278e"
+SRC_URI[sha256sum] = "c190dac598c97b0113ca5e7a37c71c623f02d1d713088addfacac4acfa4b8394"
+
+SRC_URI = "\
+    ${SOURCEFORGE_MIRROR}/pyqt/PyQt5_gpl-${PV}.tar.gz \
+"
+
+
+# remove dependency on qt4-x11-free because our Qt5 runs on eglfs
+REQUIRED_DISTRO_FEATURES=""
+
+# add some additional modules
+PYQT_MODULES_append = " QtQml QtQuick QtMultimedia QtSerialPort"
+
+DEPENDS_append = " qtdeclarative qtmultimedia qtserialport"

--- a/recipes-qt/python-pyqt5/sip_4.19.2.bbappend
+++ b/recipes-qt/python-pyqt5/sip_4.19.2.bbappend
@@ -1,0 +1,3 @@
+PV = "4.19.4"
+SRC_URI[md5sum] = "45c9fa028fba73ae66466dbd771d1d78"
+SRC_URI[sha256sum] = "59d3872b9f7d87f33dee1f87e4fa1de9bd025531d9adbb9b3581725af3121646"


### PR DESCRIPTION
I thought you might be interested in a little bit of work I did to get PyQt5 working on top of your Qt5 Yocto image.  I'm new to Yocto/oe (but not new to embedded linux or Qt) and I am not 100% sure I followed the Yocto rules of the road in terms of the recipes I wrote.  In particular I don't know if it's kosher to force a version bump by overriding PV like I did.  Seemed a little awkward since it's .bbappend that references the prior specific 5.8.2 version.  Same goes for the version bump on SIP that was required to get it to build.

I was able to build and test it for a Pi 2, and will test it on a Pi 0w soon since that is my ultimate target.  I did not package a PyQt5 test example but I can probably throw something together quickly if there's value to that.

Thanks for the work on meta-rpi, it's been a good excuse to get my foot in the door and learn a little bit of the Yocto system.