### PR TITLE
scripts: copy_boot: simplify overlay renaming command

### DIFF
--- a/scripts/copy_boot.sh
+++ b/scripts/copy_boot.sh
@@ -143,16 +143,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Stripping ${KERNEL_IMAGETYPE}- from overlay dtbos"
-case "${KERNEL_IMAGETYPE}" in
-    Image)
-        sudo rename 's/Image-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
-    zImage)
-        sudo rename 's/zImage-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
-    uImage)
-        sudo rename 's/uImage-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
+sudo rename "${KERNEL_IMAGETYPE}-" '' /media/card/overlays/*.dtbo
 esac
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Hello!

I have simplified the `rename` line in `copy_boot.sh` script.

Previously, it was failing to rename any files for my `console-image` result and returning `4` as exit code meaning `nothing was renamed`.

Thanks