### PR TITLE
On some systems, there is a `rename` utility from util-linux that is …

### DIFF
--- a/scripts/copy_boot.sh
+++ b/scripts/copy_boot.sh
@@ -129,34 +129,17 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "Copying overlay dtbos"
+echo 'Copying overlay dtbos (with prefix "${KERNEL_IMAGETYPE}-" stripped from file names)'
 for f in ${SRCDIR}/${KERNEL_IMAGETYPE}-*.dtbo; do
     if [ -L $f ]; then
-        sudo cp $f /media/card/overlays
+        fname="${f##*/}"
+        frename="${fname#${KERNEL_IMAGETYPE}-}"
+        sudo cp "$f" "/media/card/overlays/$frename"
     fi
 done
 
 if [ $? -ne 0 ]; then
     echo "Error copying overlays"
-    sudo umount ${DEV}
-    exit 1
-fi
-
-echo "Stripping ${KERNEL_IMAGETYPE}- from overlay dtbos"
-case "${KERNEL_IMAGETYPE}" in
-    Image)
-        sudo rename 's/Image-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
-    zImage)
-        sudo rename 's/zImage-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
-    uImage)
-        sudo rename 's/uImage-([\w\-]+).dtbo/$1.dtbo/' /media/card/overlays/*.dtbo
-        ;;
-esac
-
-if [ $? -ne 0 ]; then
-    echo "Error stripping overlays"
     sudo umount ${DEV}
     exit 1
 fi


### PR DESCRIPTION
…installed by default, and the Perl `rename` script with regex support might not even be available via official packages (e.g. openSUSE Tumbleweed). Instead of relying on `rename` to be the Perl script and renaming the files after copying them, use bash built-in string functions to strip the prefix directly from the destination that we are copying the files to.