### PR TITLE
Remove 'wireless-tools' from console-basic-image

### DIFF
--- a/images/console-basic-image.bb
+++ b/images/console-basic-image.bb
@@ -19,7 +19,6 @@ WIFI_SUPPORT = " \
     crda \
     iw \
     linux-firmware-raspbian \
-    wireless-tools \
     wpa-supplicant \
 "
 


### PR DESCRIPTION
'wireless-tools' is superseded by 'iw'