### PR TITLE
added rpi image generation to sample config

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -16,7 +16,7 @@ VIRTUAL-RUNTIME_init_manager = "sysvinit"
 
 MACHINE_FEATURES_remove = "apm"
 
-IMAGE_FSTYPES = "tar.xz"
+IMAGE_FSTYPES = "tar.xz rpi-sdimg"
 
 # Choose the board you are building for
 #MACHINE="raspberrypi"


### PR DESCRIPTION
Adds rpi image generation to build process. I tested generated image and it works on my rpi2 just as the one downloaded from https://jumpnowtek.com/downloads/rpi/

This way I do not have to generate image by hand as described on https://jumpnowtek.com/rpi/Raspberry-Pi-Systems-with-Yocto.html 

The only difference I found is that tspress segfaults on exit and makes terminal unusable, but I do not think that it is related to this change. I will try to look into it when I setup my dev environment (I am just starting with embedded development)

Many thanks for your article it is a real helper for newbies like me.