### PR TITLE
RPi config append init_uart_baudrate bitbake env

### DIFF
--- a/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -21,4 +21,9 @@ do_deploy_append() {
         echo "" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
         echo "dtoverlay=pi3-disable-bt" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
+
+    if [ -n "${BAUDRATE_UART}" ]; then
+        echo "" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+        echo "init_uart_baud=${BAUDRATE_UART}" >> ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    fi
 }


### PR DESCRIPTION
Hello,

I want to contribute to this repository with a bitbake configuration about the init_uart_baud of the RPi.
I created a simple variable ```BAUDRATE_UART``` to write in config.txt.